### PR TITLE
clojure.instant: add erlang.util.Date

### DIFF
--- a/src/clj/clojure/instant.clje
+++ b/src/clj/clojure/instant.clje
@@ -154,6 +154,34 @@ with invalid arguments."
 
 ;;; ------------------------------------------------------------------------
 ;;; print integration
+
+(defn- zero-left-padding
+  "Adds one zero to the left if necessary and transforms to string"
+  [int]
+  (if (< int 10)
+    (str "0" int)
+    (str int)))
+
+(defn- print-date
+  "Print a java.util.Date as RFC3339 timestamp, always in UTC.
+
+  Ex: #inst '2017-08-04T04:24:30.049-00:00'"
+  [d ^erlang.io.IWriter w]
+  (let [[[year month day] [hour minute second]] d]
+    (erlang.io.IWriter/write.e w "#inst \"")
+    (erlang.io.IWriter/write.e w (str year))
+    (erlang.io.IWriter/write.e w "-")
+    (erlang.io.IWriter/write.e w (zero-left-padding month))
+    (erlang.io.IWriter/write.e w "-")
+    (erlang.io.IWriter/write.e w (zero-left-padding day))
+    (erlang.io.IWriter/write.e w "T")
+    (erlang.io.IWriter/write.e w (zero-left-padding hour))
+    (erlang.io.IWriter/write.e w ":")
+    (erlang.io.IWriter/write.e w (zero-left-padding minute))
+    (erlang.io.IWriter/write.e w ":")
+    (erlang.io.IWriter/write.e w (zero-left-padding second))
+    (erlang.io.IWriter/write.e w ".000-00:00\"")))
+
 #_ ((def ^:private ^ThreadLocal thread-local-utc-date-format
       ;; SimpleDateFormat is not thread-safe, so we use a ThreadLocal proxy for access.
       ;; http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4228335

--- a/src/clj/clojure/instant.clje
+++ b/src/clj/clojure/instant.clje
@@ -155,7 +155,7 @@ with invalid arguments."
 ;;; ------------------------------------------------------------------------
 ;;; print integration
 
-(defn- zero-left-padding
+(defn- pad-left-zero
   "Adds one zero to the left if necessary and transforms to string"
   [int]
   (if (< int 10)
@@ -167,20 +167,9 @@ with invalid arguments."
 
   Ex: #inst '2017-08-04T04:24:30.049-00:00'"
   [^erlang.util.Date d ^erlang.io.IWriter w]
-  (let [[[year month day] [hour minute second]] (erlang.util.Date/to_erl.e d)]
-    (erlang.io.IWriter/write.e w "#inst \"")
-    (erlang.io.IWriter/write.e w (str year))
-    (erlang.io.IWriter/write.e w "-")
-    (erlang.io.IWriter/write.e w (zero-left-padding month))
-    (erlang.io.IWriter/write.e w "-")
-    (erlang.io.IWriter/write.e w (zero-left-padding day))
-    (erlang.io.IWriter/write.e w "T")
-    (erlang.io.IWriter/write.e w (zero-left-padding hour))
-    (erlang.io.IWriter/write.e w ":")
-    (erlang.io.IWriter/write.e w (zero-left-padding minute))
-    (erlang.io.IWriter/write.e w ":")
-    (erlang.io.IWriter/write.e w (zero-left-padding second))
-    (erlang.io.IWriter/write.e w ".000-00:00\"")))
+  (let [[[year month day] [hour minute second]] (erlang.util.Date/to_erl.e d)
+        out-str (format "#inst \"~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B.000-00:00\"" year month day hour minute second)]
+    (erlang.io.IWriter/write.e w out-str)))
 
 (defmethod print-method erlang.util.Date
   [^erlang.util.Date d, ^erlang.io.IWriter w]

--- a/src/clj/clojure/instant.clje
+++ b/src/clj/clojure/instant.clje
@@ -166,8 +166,8 @@ with invalid arguments."
   "Print a java.util.Date as RFC3339 timestamp, always in UTC.
 
   Ex: #inst '2017-08-04T04:24:30.049-00:00'"
-  [d ^erlang.io.IWriter w]
-  (let [[[year month day] [hour minute second]] d]
+  [^erlang.util.Date d ^erlang.io.IWriter w]
+  (let [[[year month day] [hour minute second]] (erlang.util.Date/to_erl.e d)]
     (erlang.io.IWriter/write.e w "#inst \"")
     (erlang.io.IWriter/write.e w (str year))
     (erlang.io.IWriter/write.e w "-")
@@ -182,78 +182,13 @@ with invalid arguments."
     (erlang.io.IWriter/write.e w (zero-left-padding second))
     (erlang.io.IWriter/write.e w ".000-00:00\"")))
 
-#_ ((def ^:private ^ThreadLocal thread-local-utc-date-format
-      ;; SimpleDateFormat is not thread-safe, so we use a ThreadLocal proxy for access.
-      ;; http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4228335
-      (proxy [ThreadLocal] []
-        (initialValue []
-          (doto (java.text.SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ss.SSS-00:00")
-            ;; RFC3339 says to use -00:00 when the timezone is unknown (+00:00 implies a known GMT)
-            (.setTimeZone (java.util.TimeZone/getTimeZone "GMT"))))))
+(defmethod print-method erlang.util.Date
+  [^erlang.util.Date d, ^erlang.io.IWriter w]
+  (print-date d w))
 
-    (defn- print-date
-      "Print a java.util.Date as RFC3339 timestamp, always in UTC."
-      [^java.util.Date d, ^java.io.Writer w]
-      (let [^java.text.DateFormat utc-format (.get thread-local-utc-date-format)]
-        (.write w "#inst \"")
-        (.write w (.format utc-format d))
-        (.write w "\"")))
-
-    (defmethod print-method java.util.Date
-      [^java.util.Date d, ^java.io.Writer w]
-      (print-date d w))
-
-    (defmethod print-dup java.util.Date
-      [^java.util.Date d, ^java.io.Writer w]
-      (print-date d w))
-
-    (defn- print-calendar
-      "Print a java.util.Calendar as RFC3339 timestamp, preserving timezone."
-      [^java.util.Calendar c, ^java.io.Writer w]
-      (let [calstr (format "%1$tFT%1$tT.%1$tL%1$tz" c)
-            offset-minutes (- (.length calstr) 2)]
-        ;; calstr is almost right, but is missing the colon in the offset
-        (.write w "#inst \"")
-        (.write w calstr 0 offset-minutes)
-        (.write w ":")
-        (.write w calstr offset-minutes 2)
-        (.write w "\"")))
-
-    (defmethod print-method java.util.Calendar
-      [^java.util.Calendar c, ^java.io.Writer w]
-      (print-calendar c w))
-
-    (defmethod print-dup java.util.Calendar
-      [^java.util.Calendar c, ^java.io.Writer w]
-      (print-calendar c w))
-
-
-    (def ^:private ^ThreadLocal thread-local-utc-timestamp-format
-      ;; SimpleDateFormat is not thread-safe, so we use a ThreadLocal proxy for access.
-      ;; http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4228335
-      (proxy [ThreadLocal] []
-        (initialValue []
-          (doto (java.text.SimpleDateFormat. "yyyy-MM-dd'T'HH:mm:ss")
-            (.setTimeZone (java.util.TimeZone/getTimeZone "GMT"))))))
-
-    (defn- print-timestamp
-      "Print a java.sql.Timestamp as RFC3339 timestamp, always in UTC."
-      [^java.sql.Timestamp ts, ^java.io.Writer w]
-      (let [^java.text.DateFormat utc-format (.get thread-local-utc-timestamp-format)]
-        (.write w "#inst \"")
-        (.write w (.format utc-format ts))
-        ;; add on nanos and offset
-        ;; RFC3339 says to use -00:00 when the timezone is unknown (+00:00 implies a known GMT)
-        (.write w (format ".%09d-00:00" (.getNanos ts)))
-        (.write w "\"")))
-
-    (defmethod print-method java.sql.Timestamp
-      [^java.sql.Timestamp ts, ^java.io.Writer w]
-      (print-timestamp ts w))
-
-    (defmethod print-dup java.sql.Timestamp
-      [^java.sql.Timestamp ts, ^java.io.Writer w]
-      (print-timestamp ts w)))
+(defmethod print-dup erlang.util.Date
+  [^erlang.util.Date d, ^erlang.io.IWriter w]
+  (print-date d w))
 
 ;;; ------------------------------------------------------------------------
 ;;; reader integration
@@ -275,4 +210,4 @@ milliseconds since the epoch, UTC."
 this var as the value for the 'inst key. The timezone offset will be used
   to convert into UTC."
   [date]
-  (parse-timestamp (validated construct-date) date))
+  (new erlang.util.Date (parse-timestamp (validated construct-date) date)))

--- a/src/clj/clojure/instant.clje
+++ b/src/clj/clojure/instant.clje
@@ -155,13 +155,6 @@ with invalid arguments."
 ;;; ------------------------------------------------------------------------
 ;;; print integration
 
-(defn- pad-left-zero
-  "Adds one zero to the left if necessary and transforms to string"
-  [int]
-  (if (< int 10)
-    (str "0" int)
-    (str int)))
-
 (defn- print-date
   "Print a java.util.Date as RFC3339 timestamp, always in UTC.
 
@@ -169,7 +162,7 @@ with invalid arguments."
   [^erlang.util.Date d ^erlang.io.IWriter w]
   (let [[[year month day] [hour minute second]] (erlang.util.Date/to_erl.e d)
         out-str (format "#inst \"~4.10.0B-~2.10.0B-~2.10.0BT~2.10.0B:~2.10.0B:~2.10.0B.000-00:00\"" year month day hour minute second)]
-    (erlang.io.IWriter/write.e w out-str)))
+    (.write w out-str)))
 
 (defmethod print-method erlang.util.Date
   [^erlang.util.Date d, ^erlang.io.IWriter w]

--- a/src/erl/erlang/erlang.util.Date.erl
+++ b/src/erl/erlang/erlang.util.Date.erl
@@ -22,8 +22,8 @@ to_erl(#?TYPE{data = Date}) ->
 %% Protocols
 %% ------------------------------------------------------------------------------
 
-hash(Str) ->
-  erlang:phash2(Str).
+hash(Date) ->
+  erlang:phash2(Date).
 
-equiv(#?TYPE{data = DateA}, #?TYPE{data = DateB}) ->
-  DateA == DateB.
+equiv(#?TYPE{data = Date}, #?TYPE{data = Date}) -> true;
+equiv(_ , _) -> false.

--- a/src/erl/erlang/erlang.util.Date.erl
+++ b/src/erl/erlang/erlang.util.Date.erl
@@ -1,0 +1,59 @@
+-module('erlang.util.Date').
+
+-include("clojerl.hrl").
+
+%% -behavior('clojerl.Stringable').
+-behavior('clojerl.IHash').
+
+-export([?CONSTRUCTOR/1, to_erl/1]).
+
+-export([hash/1]).
+%% -export([str/1]).
+
+-type erlang_date() :: {{integer(), integer(), integer()}, {integer(), integer(), integer()}}.
+-type type() :: #?TYPE{data :: erlang_date()}.
+
+-spec ?CONSTRUCTOR(erlang_date()) -> type().
+?CONSTRUCTOR(Date) -> #?TYPE{data = Date}.
+
+to_erl(#?TYPE{data = Date}) ->
+    Date.
+
+%% ------------------------------------------------------------------------------
+%% Protocols
+%% ------------------------------------------------------------------------------
+
+hash(Str) ->
+  erlang:phash2(Str).
+
+%% str(#?TYPE{data = Date}) -> UUID.
+
+%% %%------------------------------------------------------------------------------
+%% %% Internal
+%% %%------------------------------------------------------------------------------
+
+%% -spec uuid_to_string(binary()) -> binary().
+%% uuid_to_string(UUIDBin) ->
+%%   do_uuid_to_string(UUIDBin, 0, <<>>).
+
+%% -spec do_uuid_to_string(binary(), integer(), binary()) -> binary().
+%% do_uuid_to_string(<<>>, _Pos, Acc) ->
+%%   Acc;
+%% do_uuid_to_string(<<X:4, Rest/bits>>, Pos, Acc)
+%%   when Pos =:= 8 orelse
+%%        Pos =:= 12 orelse
+%%        Pos =:= 16 orelse
+%%        Pos =:= 20 ->
+%%   Hex = int_to_binary_hex(X),
+%%   do_uuid_to_string(Rest, Pos + 1, <<Acc/binary, "-", Hex/binary>>);
+%% do_uuid_to_string(<<X:4, Rest/bits>>, Pos, Acc) ->
+%%   Hex = int_to_binary_hex(X),
+%%   do_uuid_to_string(Rest, Pos + 1, <<Acc/binary, Hex/binary>>).
+
+%% -spec int_to_binary_hex(integer()) -> binary().
+%% int_to_binary_hex(X) when X >= 0 andalso X =< 9 ->
+%%   integer_to_binary(X);
+%% int_to_binary_hex(X) when X >= 10 andalso X =< 15 ->
+%%   <<A/utf8>> = <<"A"/utf8>>,
+%%   Hex = (A + X - 10),
+%%   <<Hex/utf8>>.

--- a/src/erl/erlang/erlang.util.Date.erl
+++ b/src/erl/erlang/erlang.util.Date.erl
@@ -10,10 +10,9 @@
 -export([hash/1]).
 -export([equiv/2]).
 
--type erlang_date() :: {{integer(), integer(), integer()}, {integer(), integer(), integer()}}.
--type type() :: #?TYPE{data :: erlang_date()}.
+-type type() :: #?TYPE{data :: calendar:datetime()}.
 
--spec ?CONSTRUCTOR(erlang_date()) -> type().
+-spec ?CONSTRUCTOR(calendar:datetime()) -> type().
 ?CONSTRUCTOR(Date) -> #?TYPE{data = Date}.
 
 to_erl(#?TYPE{data = Date}) ->

--- a/src/erl/erlang/erlang.util.Date.erl
+++ b/src/erl/erlang/erlang.util.Date.erl
@@ -2,13 +2,13 @@
 
 -include("clojerl.hrl").
 
-%% -behavior('clojerl.Stringable').
 -behavior('clojerl.IHash').
+-behavior('clojerl.IEquiv').
 
 -export([?CONSTRUCTOR/1, to_erl/1]).
 
 -export([hash/1]).
-%% -export([str/1]).
+-export([equiv/2]).
 
 -type erlang_date() :: {{integer(), integer(), integer()}, {integer(), integer(), integer()}}.
 -type type() :: #?TYPE{data :: erlang_date()}.
@@ -26,34 +26,5 @@ to_erl(#?TYPE{data = Date}) ->
 hash(Str) ->
   erlang:phash2(Str).
 
-%% str(#?TYPE{data = Date}) -> UUID.
-
-%% %%------------------------------------------------------------------------------
-%% %% Internal
-%% %%------------------------------------------------------------------------------
-
-%% -spec uuid_to_string(binary()) -> binary().
-%% uuid_to_string(UUIDBin) ->
-%%   do_uuid_to_string(UUIDBin, 0, <<>>).
-
-%% -spec do_uuid_to_string(binary(), integer(), binary()) -> binary().
-%% do_uuid_to_string(<<>>, _Pos, Acc) ->
-%%   Acc;
-%% do_uuid_to_string(<<X:4, Rest/bits>>, Pos, Acc)
-%%   when Pos =:= 8 orelse
-%%        Pos =:= 12 orelse
-%%        Pos =:= 16 orelse
-%%        Pos =:= 20 ->
-%%   Hex = int_to_binary_hex(X),
-%%   do_uuid_to_string(Rest, Pos + 1, <<Acc/binary, "-", Hex/binary>>);
-%% do_uuid_to_string(<<X:4, Rest/bits>>, Pos, Acc) ->
-%%   Hex = int_to_binary_hex(X),
-%%   do_uuid_to_string(Rest, Pos + 1, <<Acc/binary, Hex/binary>>).
-
-%% -spec int_to_binary_hex(integer()) -> binary().
-%% int_to_binary_hex(X) when X >= 0 andalso X =< 9 ->
-%%   integer_to_binary(X);
-%% int_to_binary_hex(X) when X >= 10 andalso X =< 15 ->
-%%   <<A/utf8>> = <<"A"/utf8>>,
-%%   Hex = (A + X - 10),
-%%   <<Hex/utf8>>.
+equiv(#?TYPE{data = DateA}, #?TYPE{data = DateB}) ->
+  DateA == DateB.

--- a/test/clj/clojure/test_clojure/clojure_instant.clje
+++ b/test/clj/clojure/test_clojure/clojure_instant.clje
@@ -4,4 +4,5 @@
 
 (deftest test-roundtrip
   (is (= "#inst \"1990-12-19T10:10:00.000-00:00\"" (pr-str #inst "1990-12-19T10:10:00.000-00:00")))
-  (is (= #erl[#erl[1990 12 19] #erl[10 10 0]] (erlang.util.Date/to_erl.e #inst "1990-12-19T10:10:00.000-00:00"))))
+  (is (= #erl[#erl[1990 12 19] #erl[10 10 0]] (erlang.util.Date/to_erl.e #inst "1990-12-19T10:10:00.000-00:00")))
+  (is (= (type (calendar/local_time.e)) (type (erlang.util.Date/to_erl.e #inst "1990-12-19T10:10:00.000-00:00")))))

--- a/test/clj/clojure/test_clojure/clojure_instant.clje
+++ b/test/clj/clojure/test_clojure/clojure_instant.clje
@@ -1,0 +1,7 @@
+(ns clojure.test-clojure.clojure-instant
+  (:use clojure.test)
+  (:require [clojure.instant :as instant]))
+
+(deftest test-roundtrip
+  (is (= "#inst \"1990-12-19T10:10:00.000-00:00\"" (pr-str #inst "1990-12-19T10:10:00.000-00:00")))
+  (is (= #erl[#erl[1990 12 19] #erl[10 10 0]] (erlang.util.Date/to_erl.e #inst "1990-12-19T10:10:00.000-00:00"))))

--- a/test/clj/clojure/test_clojure/reader.cljc
+++ b/test/clj/clojure/test_clojure/reader.cljc
@@ -411,16 +411,16 @@
                (is (= clojure.core// bar//))))))
 
 (deftest Instants
-  (testing "Instants are read as Erlang's calendar:datetime() by default"
-    (is (= clojerl.erlang.Tuple (type #inst "2010-11-12T13:14:15.666"))))
+  (testing "Instants are read as erlang.util.Date by default"
+    (is (= erlang.util.Date (type #inst "2010-11-12T13:14:15.666"))))
   (let [s "#inst \"2010-11-12T13:14:15.666-06:00\""]
     (binding [*data-readers* {'inst read-instant-date}]
       (testing "read-instant-date produces calendar:datetime()"
-        (is (= clojerl.erlang.Tuple (type (read-string s)))))
-      (testing "calendar:datetime() instants round-trips"
+        (is (= erlang.util.Date (type (read-string s)))))
+      (testing "Date round-trips"
         (is (= (-> s read-string)
                (-> s read-string pr-str read-string))))
-      (testing "calendar:datetime() instants round-trip throughout the year"
+      (testing "Date round-trips throughout the year"
         (doseq [month (range 1 13) day (range 1 29) hour (range 1 23)]
           (let [s (format "#inst \"2010-~2.10.0B-~2.10.0BT~2.10.0B:14:15.666-06:00\"" month day hour)]
             (is (= (-> s read-string)

--- a/test/clj_reader_SUITE.erl
+++ b/test/clj_reader_SUITE.erl
@@ -1146,7 +1146,7 @@ tagged(Config) when is_list(Config) ->
   tagged(fun read/1),
   tagged(fun read_io/1);
 tagged(ReadFun) ->
-  Date2016 = {{2016, 1, 1}, {0, 0, 0}},
+  Date2016 = 'erlang.util.Date':?CONSTRUCTOR({{2016, 1, 1}, {0, 0, 0}}),
   UUIDBin  = <<"de305d54-75b4-431b-adb2-eb6b9e546014">>,
   UUID     = 'erlang.util.UUID':?CONSTRUCTOR(UUIDBin),
   ct:comment("Use default readers"),


### PR DESCRIPTION
If merged, closes #262. 

- Adds a new type, `erlang.util.Date`, following the template provided by `erlang.util.Regex` and `erlang.util.UUID`, also mirroring the `java.util.*` classes.
- The type comes with `equiv` and `hash`. I didn't add `str` because it involved more complicated date printing (month names, etc.)
- Uses the new type in the reader.
- Dispatches off the type on `print-method`.

I don't write much Erlang, so please forgive me for any obvious blunders. If you can please point them out, I'll correct them.